### PR TITLE
Merge tag 'android-security-10.0.0_r52'

### DIFF
--- a/bta/ag/bta_ag_sdp.cc
+++ b/bta/ag/bta_ag_sdp.cc
@@ -34,6 +34,7 @@
 #include "bta_sys.h"
 #include "btif_config.h"
 #include "btm_api.h"
+#include "osi/include/log.h"
 #include "osi/include/osi.h"
 #include "sdp_api.h"
 #include "stack/include/btu.h"
@@ -475,6 +476,12 @@ void bta_ag_do_disc(tBTA_AG_SCB* p_scb, tBTA_SERVICE_MASK service) {
       /* Legacy from HSP v1.0 */
       uuid_list[0] = Uuid::From16Bit(UUID_SERVCLASS_HEADSET);
     }
+  }
+
+  if (p_scb->p_disc_db != nullptr) {
+    android_errorWriteLog(0x534e4554, "174052148");
+    APPL_TRACE_ERROR("Discovery already in progress... returning.");
+    return;
   }
 
   /* allocate buffer for sdp database */


### PR DESCRIPTION
Android Security 10.0.0 Release 52 (7070703)

* tag 'android-security-10.0.0_r52':
  SDP: Only start discovery once

Change-Id: I2774d84af42d63560ccbc72779904f0d9add5142